### PR TITLE
GEN-865 updated jackson, joda, httpclient jars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ workspace.xml
 Maven__org_hamcrest_hamcrest_all_1_3.xml
 .idea
 genability-client.iml
+*.iml
+
+

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The Genability API Java client library is now available on the Maven Central Rep
 <dependency>
   <groupId>com.genability</groupId>
   <artifactId>genability-client</artifactId>
-  <version>1.10.0</version>
+  <version>1.11.0</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>com.genability</groupId>
 	<artifactId>genability-client</artifactId>
-	<version>1.10.0</version>
+	<version>1.11.0</version>
 	<name>${project.groupId}:${project.artifactId}</name>
 	<description>Genability API Java Client</description>
 	<url>http://github.com/Genability/genability-java/</url>
@@ -41,9 +41,9 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<httpclient.version>4.3.1</httpclient.version>
-		<jackson.version>2.3.0</jackson.version>
-		<jodatime.version>2.3</jodatime.version>
+		<httpclient.version>4.5.3</httpclient.version>
+		<jackson.version>2.9.7</jackson.version>
+		<jodatime.version>2.9.9</jodatime.version>
 		<slf4j.version>1.7.5</slf4j.version>
 		<junit.version>4.11</junit.version>
 	</properties>
@@ -79,6 +79,12 @@
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
 			<version>${jackson.version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>com.fasterxml.jackson.core</groupId>
+					<artifactId>jackson-annotations</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.datatype</groupId>
@@ -88,6 +94,10 @@
 				<exclusion>
 					<groupId>joda-time</groupId>
 					<artifactId>joda-time</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.fasterxml.jackson.core</groupId>
+					<artifactId>jackson-annotations</artifactId>
 				</exclusion>
 			</exclusions>
 		</dependency>

--- a/src/main/java/com/genability/client/api/service/BaseService.java
+++ b/src/main/java/com/genability/client/api/service/BaseService.java
@@ -6,6 +6,9 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.genability.client.util.JodaDateJsonSerializer;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
@@ -29,6 +32,7 @@ import org.apache.http.entity.mime.MultipartEntityBuilder;
 import org.apache.http.entity.mime.content.FileBody;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.util.EntityUtils;
+import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -61,6 +65,9 @@ public class BaseService {
 	    mapper.enable(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL);
 	    mapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
 	    mapper.setSerializationInclusion(Include.NON_NULL);
+		SimpleModule module = new SimpleModule();
+		module.addSerializer(DateTime.class, new JodaDateJsonSerializer());
+		mapper.registerModule(module);
     }
 
 	/**

--- a/src/main/java/com/genability/client/util/JodaDateJsonSerializer.java
+++ b/src/main/java/com/genability/client/util/JodaDateJsonSerializer.java
@@ -1,0 +1,34 @@
+package com.genability.client.util;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import org.joda.time.DateTime;
+import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.DateTimeFormatter;
+
+import java.io.IOException;
+
+/**
+ * This is a custom serializer for serializing java.sql.DateTime into JSON.
+ * This is used by all requests containing DateTimes.
+ * 
+ * {code}
+ * 
+ * @JsonSerialize(using=SqlDateJsonSerializer.class) {code}
+ * 
+ */
+public class JodaDateJsonSerializer extends JsonSerializer<DateTime> {
+	
+	public static final String ISO_8601_DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ssZZ";
+
+	@Override
+	public void serialize(DateTime dateTime, JsonGenerator jgen, SerializerProvider provider) throws IOException {
+
+		if (dateTime != null) {
+			DateTimeFormatter fmt = DateTimeFormat.forPattern(ISO_8601_DATE_FORMAT);
+			jgen.writeString(fmt.print(dateTime));
+		}
+	}
+
+}

--- a/src/test/java/com/genability/client/api/request/AccountAnalysisRequestTests.java
+++ b/src/test/java/com/genability/client/api/request/AccountAnalysisRequestTests.java
@@ -2,6 +2,10 @@ package com.genability.client.api.request;
 
 import static org.junit.Assert.*;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.genability.client.util.JodaDateJsonSerializer;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.LocalDate;
@@ -21,7 +25,12 @@ public class AccountAnalysisRequestTests {
 	public void registerJodaModule() {
 		mapper.registerModule(new JodaModule());
 		mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
-	    mapper.setSerializationInclusion(Include.NON_NULL);
+		mapper.enable(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL);
+		mapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+		mapper.setSerializationInclusion(Include.NON_NULL);
+		SimpleModule module = new SimpleModule();
+		module.addSerializer(DateTime.class, new JodaDateJsonSerializer());
+		mapper.registerModule(module);
 	}
 	
 	
@@ -65,7 +74,7 @@ public class AccountAnalysisRequestTests {
 	public void testFromDateWithTimezone() throws JsonProcessingException {
 		AccountAnalysisRequest request = new AccountAnalysisRequest();
 		request.setFromDateTime(new DateTime(2015, 1, 1, 0, 0, 0, DateTimeZone.forID("US/Pacific")));
-		String target = "{\"fields\":\"ext\",\"fromDateTime\":\"2015-01-01T00:00:00.000-08:00\"}";
+		String target = "{\"fields\":\"ext\",\"fromDateTime\":\"2015-01-01T00:00:00-08:00\"}";
 		
 		assertEquals("Didn't serialize fromDateTime correctly with a datetime", target, mapper.writeValueAsString(request));
 	}
@@ -74,8 +83,7 @@ public class AccountAnalysisRequestTests {
 	public void testToDateWithTimezone() throws JsonProcessingException {
 		AccountAnalysisRequest request = new AccountAnalysisRequest();
 		request.setToDateTime(new DateTime(2015, 1, 1, 0, 0, 0, DateTimeZone.forID("US/Pacific")));
-		String target = "{\"fields\":\"ext\",\"toDateTime\":\"2015-01-01T00:00:00.000-08:00\"}";
-		
+		String target = "{\"fields\":\"ext\",\"toDateTime\":\"2015-01-01T00:00:00-08:00\"}";
 		assertEquals("Didn't serialize toDateTime correctly with a datetime", target, mapper.writeValueAsString(request));
 	}
 }

--- a/src/test/java/com/genability/client/api/request/GetTariffRequestTests.java
+++ b/src/test/java/com/genability/client/api/request/GetTariffRequestTests.java
@@ -4,10 +4,35 @@ import static org.junit.Assert.*;
 
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.datatype.joda.JodaModule;
+import com.genability.client.util.JodaDateJsonSerializer;
 import org.apache.http.NameValuePair;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.junit.Before;
 import org.junit.Test;
 
 public class GetTariffRequestTests {
+	
+	private ObjectMapper mapper = new ObjectMapper();
+	
+	@Before
+	public void registerJodaModule() {
+		mapper.registerModule(new JodaModule());
+		mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+		mapper.enable(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_AS_NULL);
+		mapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+		mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+		SimpleModule module = new SimpleModule();
+		module.addSerializer(DateTime.class, new JodaDateJsonSerializer());
+		mapper.registerModule(module);
+	}
 
 	@Test
 	public void testTerritoryIdParameter() {
@@ -24,5 +49,13 @@ public class GetTariffRequestTests {
 		}
 		
 		assertTrue("Got no/incorrect territoryId", foundTerritoryId);
+	}
+	
+	@Test
+	public void testToDateWithTimezone() throws JsonProcessingException {
+		GetTariffRequest request = new GetTariffRequest();
+		request.setEffectiveOn(new DateTime(2015, 1, 1, 0, 0, 0, DateTimeZone.forID("US/Pacific")));
+		String target = "{\"fields\":\"ext\",\"effectiveOn\":\"2015-01-01T00:00:00-08:00\"}";
+		assertEquals("Didn't serialize toDateTime correctly with a datetime", target, mapper.writeValueAsString(request));
 	}
 }


### PR DESCRIPTION
- Updated jackson, joda and httpclient library dependencies to most recent versions to address security vulnerabilities:
https://nvd.nist.gov/vuln/detail/CVE-2015-5262
https://nvd.nist.gov/vuln/detail/CVE-2017-17485
https://nvd.nist.gov/vuln/detail/CVE-2018-7489
https://nvd.nist.gov/vuln/detail/CVE-2017-7525
- Now uses DateTime serialization consistent with server side, in part to ensure that the context timezone is used. Note that this does not serialize milliseconds.