### PR TITLE
Adding a gitignored local properties file to avoid accidentally comitting creds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ genability-client.iml
 *.iml
 
 
+# Ignore local properties override to avoid accidentally comitting creds
+src/test/resources/genability.local.properties

--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ You'll still need an appId and appKey to make any requests. Get an appId at http
 Be sure to check out the [tutorial](http://genability.github.io/genability-java/tutorial.html) and the [tutorial app](https://github.com/Genability/java-client-tutorial) for some examples to get you started.
 
 # How to Run the Tests
-1. Get an appId and appKey.
-2. Put the appId and appKey in the `src/test/resources/genability.properties` file.
-3. Compile the library and run JUnit tests with `mvn test`.
-4. Develop your own app. Read the API documentation at http://developer.genability.com.
+1. Get a Genability appId and appKey.
+2. Copy the `src/test/resources/genability.properties` file into a new `src/test/resources/genability.local.properties`. This copy is gitignored.
+3. Fill in your appId and appKey into the `.local.properties`.
+4. Run `mvn test`: compiles the library and runs JUnit tests.
+5. Develop your own app. Read the API documentation at http://developer.genability.com.

--- a/src/test/java/com/genability/client/api/service/BaseServiceTests.java
+++ b/src/test/java/com/genability/client/api/service/BaseServiceTests.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.SequenceInputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -75,10 +76,17 @@ public class BaseServiceTests {
     		//load the properties file from in the classpath
     		//
     		InputStream inputStream = BaseServiceTests.class.getClassLoader().getResourceAsStream("genability.properties");
-                if (inputStream == null) {
-                        logger.error("Can't find genability.properties");
-                        throw new RuntimeException("Can't find genability.properties");
-                }
+			if (inputStream == null) {
+				logger.error("Can't find genability.properties");
+				throw new RuntimeException("Can't find genability.properties");
+			}
+
+			// Also try loading the (gitignore'd) local overrides
+			InputStream localProps = BaseServiceTests.class.getClassLoader().getResourceAsStream("genability.local.properties");
+			if (localProps != null) {
+				inputStream = new SequenceInputStream(inputStream, localProps);
+			}
+
     		prop.load(inputStream);
     	} catch (IOException ex) {
     		logger.error("Unable to process genability.properties", ex);

--- a/src/test/resources/genability.properties
+++ b/src/test/resources/genability.properties
@@ -1,3 +1,7 @@
+# Properties Template: Read by BaseServiceTests to initialize GenabilityClient instance used by tests.
+# TO USE: Copy this file into a new `genability.local.properties` files and fill them in.
+# The `.local.properties` is gitignored so you won't accidentally commit credentials.
+
 #
 # CREDENTIALS TO USE
 # Enter your appId and appKey below (get one from http://developer.genability.com)
@@ -8,8 +12,7 @@ appKey=
 
 #
 # SERVER TO CALL
-# If you are using production, you don't need to set the server URL.
+# If you are using production, you don't need to set the server URL (defaults to https://api.genability.com/rest/)
 # Otherwise, specify the URL as such https://SERVERURL/rest/
 #
 restApiServer=
-#


### PR DESCRIPTION
Lets you specify credits using a gitignored `genability.local.properties` file, which will help avoid accidental cred leaks