### PR TITLE
bug/GEN-2601/update-max-tariff

### DIFF
--- a/src/test/java/com/genability/client/api/service/TariffServiceTests.java
+++ b/src/test/java/com/genability/client/api/service/TariffServiceTests.java
@@ -66,8 +66,8 @@ public class TariffServiceTests extends BaseServiceTests {
 	@Test
 	public void testGetTariffWithChargeTypeMaximum() {
 		GetTariffRequest request = new GetTariffRequest();
-		request.setMasterTariffId(3311025L);
-		request.setEffectiveOn(new DateTime("2021-06-02"));
+		request.setMasterTariffId(3342081L);
+		request.setEffectiveOn(new DateTime("2020-03-01"));
 
 		Tariff tariff = callGetTariff("Tariff with ChargeType MAXIMUM", request);
 


### PR DESCRIPTION
This test was failing due to a recent data update which removed the Maximum charge type from the given tariff. Selected a different tariff now, which does currently have this charge type.