### PR TITLE
feat add new ChargeCLass.NET_EXCESS

### DIFF
--- a/src/main/java/com/genability/client/types/ChargeClass.java
+++ b/src/main/java/com/genability/client/types/ChargeClass.java
@@ -9,5 +9,6 @@ public enum ChargeClass {
   CONTRACTED,
   USER_ADJUSTED,
   AFTER_TAX,
-  NON_BYPASSABLE
+  NON_BYPASSABLE,
+  NET_EXCESS
 }


### PR DESCRIPTION
Fix for:

```
ERROR:
  Code: InvalidArgument
  Message: INVALID_ARGUMENT: com.fasterxml.jackson.databind.JsonMappingException: No enum constant com.genability.client.types.ChargeClass.NET_EXCESS
 at [Source: (org.apache.http.client.entity.LazyDecompressingInputStream); line: 1, column: 98333] (through reference chain: com.genability.client.types.Response["results"]->java.util.ArrayList[0]->com.genability.client.types.Tariff["rates"]->java.util.ArrayList[46]->com.genability.client.types.TariffRate["chargeClass"])
```