### PR TITLE
Probably due to some change in another library, the output of this te…

### DIFF
--- a/src/test/java/com/genability/client/api/service/TimeOfUseServiceTests.java
+++ b/src/test/java/com/genability/client/api/service/TimeOfUseServiceTests.java
@@ -208,7 +208,7 @@ public class TimeOfUseServiceTests extends BaseServiceTests {
 			touService.getTimeOfUseGroup(added.getLseId(), added.getTouGroupId());
 		} catch (GenabilityException e) {
 			String message = "Trying to get a deleted TOU group should result in a 404";
-			assertEquals(message, "Failed : HTTP error code : 404", e.getMessage());
+			assertEquals(message, "Failed GET " + publicBaseUrl + "/" + added.getLseId() + "/" + added.getTouGroupId() + "?fields=ext: HTTP error code : 404", e.getMessage());
 		}
 	}
 


### PR DESCRIPTION
…st error has changed to populate the request url instead of not