### PR TITLE
add exportDataSeries to PropertyData

### DIFF
--- a/src/main/java/com/genability/client/types/PropertyData.java
+++ b/src/main/java/com/genability/client/types/PropertyData.java
@@ -53,7 +53,9 @@ public class PropertyData {
 	private String operator;
 
 	private List<BigDecimal> dataSeries;
-	
+
+	private List<BigDecimal> exportDataSeries;
+
 	public PropertyData() {}
 
 	public void setKeyName(String keyName) {
@@ -194,6 +196,14 @@ public class PropertyData {
 
 	public void setDataSeries(List<BigDecimal> dataSeries) {
 		this.dataSeries = dataSeries;
+	}
+
+	public List<BigDecimal> getExportDataSeries() {
+		return exportDataSeries;
+	}
+
+	public void setExportDataSeries(List<BigDecimal> exportDataSeries) {
+		this.exportDataSeries = exportDataSeries;
 	}
 
 	public void addData(BigDecimal data) {


### PR DESCRIPTION
Customer filed issue: 

["I was trying CostCalculation and found exportDataSeries is missing from PropertyData. is there another way to set export data in my cost calculation. please help"](https://github.com/Genability/genability-java/issues/63)