### PR TITLE
Add TimeOfUseType enum ALL

### DIFF
--- a/src/main/java/com/genability/client/types/TimeOfUseType.java
+++ b/src/main/java/com/genability/client/types/TimeOfUseType.java
@@ -7,4 +7,5 @@ public enum TimeOfUseType {
 	CRITICAL_PEAK,
 	SUPER_OFF_PEAK,
 	SUPER_ON_PEAK,
+	ALL,
 }

--- a/src/main/java/com/genability/client/types/TimeOfUseType.java
+++ b/src/main/java/com/genability/client/types/TimeOfUseType.java
@@ -7,5 +7,5 @@ public enum TimeOfUseType {
 	CRITICAL_PEAK,
 	SUPER_OFF_PEAK,
 	SUPER_ON_PEAK,
-	ALL,
+	ALL
 }


### PR DESCRIPTION
Per this issue raised: https://github.com/Genability/genability-java/issues/41

The ALL enum in TimeOfUseType is not present in the client library. We'll simply add it, since it seems to still be in use.