### PR TITLE
GEN-5150/GEN-5151 sdk

### DIFF
--- a/src/test/java/com/genability/client/api/service/AccountServiceTests.java
+++ b/src/test/java/com/genability/client/api/service/AccountServiceTests.java
@@ -132,6 +132,13 @@ public class AccountServiceTests  extends BaseServiceTests {
 		}
 		
 		try {
+			// Add a delay to allow for indexing
+			try {
+				Thread.sleep(2000);
+			} catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+			}
+			
 			GetAccountsRequest request = new GetAccountsRequest();
 			request.setPageCount(pageCount);
 			request.setSearch("JAVA CLIENT TEST ACCOUNT");

--- a/src/test/java/com/genability/client/api/service/AccountServiceTests.java
+++ b/src/test/java/com/genability/client/api/service/AccountServiceTests.java
@@ -132,7 +132,9 @@ public class AccountServiceTests  extends BaseServiceTests {
 		}
 		
 		try {
-			// Add a delay to allow for indexing
+			// Delay to mitigate potential race condition where newly created accounts aren't immediately searchable
+			// Could be due to indexing delay or read-replica sync delay.
+			// 2000ms is a best-guess based on some testing; if this test continues to fail, consider increasing this delay.
 			try {
 				Thread.sleep(2000);
 			} catch (InterruptedException e) {

--- a/src/test/java/com/genability/client/api/service/TimeOfUseServiceTests.java
+++ b/src/test/java/com/genability/client/api/service/TimeOfUseServiceTests.java
@@ -213,7 +213,17 @@ public class TimeOfUseServiceTests extends BaseServiceTests {
 	}
 
 	private void cleanUpPrivateTou(TimeOfUseGroup grp) {
-		touService.deletePrivateTimeOfUseGroup(grp.getLseId(), grp.getTouGroupId());
+		try {
+			// Check if the TOU group has been deleted
+			Response<TimeOfUseGroup> verifyResponse = touService.getTimeOfUseGroup(grp.getLseId(), grp.getTouGroupId());
+			if (verifyResponse.getStatus() == Response.STATUS_SUCCESS) {
+				touService.deletePrivateTimeOfUseGroup(grp.getLseId(), grp.getTouGroupId());
+			}
+		} catch (GenabilityException e) {
+			if (!e.getMessage().contains("404")) {
+				throw e;
+			}
+		}
 	}
 	
 	/**		


### PR DESCRIPTION
**Intermittent failure: SDK > TimeOfUseServiceTests.addPrivateTouGroupWorksCorrectly**

The test itself passes (adding the TOU group works)
The failure occurs during cleanup with a 404 error when trying to delete the TOU group
The resource was getting deleted by another process or there's a race condition

```
family-main-sdk-lnc5p: addPrivateTouGroupWorksCorrectly(com.genability.client.api.service.TimeOfUseServiceTests)  Time elapsed: 0.06 sec  <<< ERROR!
family-main-sdk-lnc5p: com.genability.client.api.service.GenabilityException: Failed DELETE http://family-main-preview/rest/timeofuses/734/634: HTTP error code : 404
```

**Intermittent failure: SDK > AccountServiceTests.testPaginatedAccountList:139**

```
family-main-sdk-lnc5p: testPaginatedAccountList(com.genability.client.api.service.AccountServiceTests)  Time elapsed: 20.444 sec  <<< ERROR!
family-main-sdk-lnc5p: com.genability.client.api.service.GenabilityException: Failed GET http://family-main-preview/rest/v1/accounts?fields=ext&pageCount=5&search=JAVA+CLIENT+TEST+ACCOUNT&searchOn=accountName: HTTP error code : 500
```

<img width="589" alt="Screenshot 2025-05-12 at 1 15 36 PM" src="https://github.com/user-attachments/assets/865b7434-4ca4-42f1-a3ec-5dfc8941dec7" />
