### PR TITLE
Fix intermittent failures in AccountServiceTests

### DIFF
--- a/src/test/java/com/genability/client/api/service/AccountServiceTests.java
+++ b/src/test/java/com/genability/client/api/service/AccountServiceTests.java
@@ -122,21 +122,53 @@ public class AccountServiceTests  extends BaseServiceTests {
 		int numberOfAccountsToCreate = 10;
 		int pageCount = 5;
 		String[] createdAccountIds = new String[numberOfAccountsToCreate];
+		String uniqueIdentifier = UUID.randomUUID().toString().substring(0, 8);
 		
 		for(int i = 0; i < numberOfAccountsToCreate; i++) {
 			Account newAccount = new Account();
-			newAccount.setAccountName(String.format("JAVA CLIENT TEST ACCOUNT #%d - CAN DELETE", i));
+			newAccount.setAccountName(String.format("JAVA CLIENT TEST ACCOUNT %s #%d - CAN DELETE", uniqueIdentifier, i));
 			
 			Account addedAccount = addAccount(newAccount);
 			createdAccountIds[i] = addedAccount.getAccountId();
 		}
 		
 		try {
+			// Add a short delay to allow for server indexing
+			try {
+				Thread.sleep(500);
+			} catch (InterruptedException e) {
+				// Ignore interruption
+			}
+			
 			GetAccountsRequest request = new GetAccountsRequest();
 			request.setPageCount(pageCount);
-			request.setSearch("JAVA CLIENT TEST ACCOUNT");
+			request.setSearch("JAVA CLIENT TEST ACCOUNT " + uniqueIdentifier);
 			request.setSearchOn("accountName");
-			Response<Account> restResponse = accountService.getAccounts(request);
+			
+			// Retry logic for intermittent server errors
+			Response<Account> restResponse = null;
+			int retryCount = 0;
+			int maxRetries = 3;
+			
+			while (retryCount < maxRetries) {
+				try {
+					restResponse = accountService.getAccounts(request);
+					break; // Success, exit the retry loop
+				} catch (GenabilityException e) {
+					retryCount++;
+					if (retryCount >= maxRetries) {
+						throw e; // Re-throw if we've exhausted retries
+					}
+					
+					System.out.println("Search request failed, retrying (" + retryCount + "/" + maxRetries + ")");
+					try {
+						Thread.sleep(500 * retryCount); // Exponential backoff
+					} catch (InterruptedException ie) {
+						// Ignore interruption
+					}
+				}
+			}
+
 			
 			int totalAccounts = restResponse.getCount();
 			int accountsVisited = 0;
@@ -146,6 +178,11 @@ public class AccountServiceTests  extends BaseServiceTests {
 				assertEquals("Didn't page through the account list correctly.", accountsVisited, restResponse.getPageStart().intValue());
 	
 				accountsVisited += restResponse.getResults().size();
+				
+				// Don't make another request if we've seen all accounts
+				if (accountsVisited >= totalAccounts) {
+					break;
+				}
 				
 				request.setPageStart(restResponse.getPageStart() + restResponse.getPageCount());
 				restResponse = accountService.getAccounts(request);

--- a/src/test/java/com/genability/client/api/service/AccountServiceTests.java
+++ b/src/test/java/com/genability/client/api/service/AccountServiceTests.java
@@ -160,7 +160,6 @@ public class AccountServiceTests  extends BaseServiceTests {
 						throw e; // Re-throw if we've exhausted retries
 					}
 					
-					System.out.println("Search request failed, retrying (" + retryCount + "/" + maxRetries + ")");
 					try {
 						Thread.sleep(500 * retryCount); // Exponential backoff
 					} catch (InterruptedException ie) {

--- a/src/test/java/com/genability/client/api/service/AccountServiceTests.java
+++ b/src/test/java/com/genability/client/api/service/AccountServiceTests.java
@@ -27,6 +27,9 @@ import static org.hamcrest.CoreMatchers.equalTo;
 
 public class AccountServiceTests  extends BaseServiceTests {
 
+	private static final int MAX_RETRIES = 3;
+	private static final int SLEEP_TIME = 500;
+
 	@Test
 	public void testAddAccount() {
 		//test
@@ -135,7 +138,7 @@ public class AccountServiceTests  extends BaseServiceTests {
 		try {
 			// Add a short delay to allow for server indexing
 			try {
-				Thread.sleep(500);
+				Thread.sleep(SLEEP_TIME);
 			} catch (InterruptedException e) {
 				// Ignore interruption
 			}
@@ -148,20 +151,19 @@ public class AccountServiceTests  extends BaseServiceTests {
 			// Retry logic for intermittent server errors
 			Response<Account> restResponse = null;
 			int retryCount = 0;
-			int maxRetries = 3;
 			
-			while (retryCount < maxRetries) {
+			while (retryCount < MAX_RETRIES) {
 				try {
 					restResponse = accountService.getAccounts(request);
 					break; // Success, exit the retry loop
 				} catch (GenabilityException e) {
 					retryCount++;
-					if (retryCount >= maxRetries) {
+					if (retryCount >= MAX_RETRIES) {
 						throw e; // Re-throw if we've exhausted retries
 					}
 					
 					try {
-						Thread.sleep(500 * retryCount); // Exponential backoff
+						Thread.sleep(SLEEP_TIME * retryCount); // Exponential backoff
 					} catch (InterruptedException ie) {
 						// Ignore interruption
 					}


### PR DESCRIPTION
Problem
The testPaginatedAccountList test in AccountServiceTests was experiencing intermittent 500 errors when searching for newly created accounts:
`GenabilityException: Failed GET http://family-main-preview/rest/v1/accounts?fields=ext&pageCount=5&search=JAVA+CLIENT+TEST+ACCOUNT&searchOn=accountName: HTTP error code : 500
`
The issue occurred because:
1. Multiple test runs would create accounts with identical names
2. The server's search index needed time to update after account creation
3. No resilience against temporary server errors when multiple tests ran concurrently

Previous PR: https://github.com/Genability/genability-java/pull/76 (tackling each tests separately now)